### PR TITLE
Implement draft and publish recipe logic

### DIFF
--- a/backend/src/recipes/recipe.controller.ts
+++ b/backend/src/recipes/recipe.controller.ts
@@ -174,3 +174,37 @@ export const getRecipeForEdit = async (
     next(error);
   }
 };
+
+export const publishRecipe = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const recipeId = req.params.id as string;
+    const userId = req.userId!;
+
+    const recipe = await recipeService.publishRecipe(recipeId, userId);
+
+    res.json(recipe);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const unpublishRecipe = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const recipeId = req.params.id as string;
+    const userId = req.userId!;
+
+    const recipe = await recipeService.unpublishRecipe(recipeId, userId);
+
+    res.json(recipe);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/recipes/recipe.routes.ts
+++ b/backend/src/recipes/recipe.routes.ts
@@ -25,18 +25,17 @@ router.get('/search', searchRecipes);
 // Authenticated routes
 router.get('/my-recipes', authenticate, getMyRecipes);
 router.get('/:id/edit', authenticate, getRecipeForEdit);
-router.patch('/:id/status', authenticate, updateRecipeStatus);
 
-// Public viewing
-router.get('/', getPublishedRecipes);
-router.patch('/:id/publish', authenticate, publishRecipe);
-router.patch('/:id/unpublish', authenticate, unpublishRecipe);
-router.get('/:id', getRecipeById);
 router.post('/', authenticate, createRecipe);
 router.put('/:id', authenticate, updateRecipe);
 router.delete('/:id', authenticate, deleteRecipe);
 
+// Draft & Publish logic
 router.patch('/:id/publish', authenticate, publishRecipe);
 router.patch('/:id/unpublish', authenticate, unpublishRecipe);
+
+// Public viewing
+router.get('/', getPublishedRecipes);
+router.get('/:id', getRecipeById);
 
 export default router;

--- a/backend/src/recipes/recipe.routes.ts
+++ b/backend/src/recipes/recipe.routes.ts
@@ -36,4 +36,7 @@ router.post('/', authenticate, createRecipe);
 router.put('/:id', authenticate, updateRecipe);
 router.delete('/:id', authenticate, deleteRecipe);
 
+router.patch('/:id/publish', authenticate, publishRecipe);
+router.patch('/:id/unpublish', authenticate, unpublishRecipe);
+
 export default router;

--- a/backend/src/recipes/recipe.routes.ts
+++ b/backend/src/recipes/recipe.routes.ts
@@ -11,6 +11,8 @@ import {
   getRecentRecipes,
   searchRecipes,
   getRecipeForEdit,
+  publishRecipe,
+  unpublishRecipe,
 } from './recipe.controller';
 
 const router = Router();
@@ -21,8 +23,9 @@ router.get('/search', searchRecipes);
 router.get('/my-recipes', authenticate, getMyRecipes);
 router.get('/:id/edit', authenticate, getRecipeForEdit);
 router.get('/', getPublishedRecipes);
+router.patch('/:id/publish', authenticate, publishRecipe);
+router.patch('/:id/unpublish', authenticate, unpublishRecipe);
 router.get('/:id', getRecipeById);
-
 router.post('/', authenticate, createRecipe);
 router.put('/:id', authenticate, updateRecipe);
 router.delete('/:id', authenticate, deleteRecipe);

--- a/backend/src/recipes/recipe.service.ts
+++ b/backend/src/recipes/recipe.service.ts
@@ -147,6 +147,7 @@ export const getPublishedRecipeById = async (id: string) => {
     where: {
       id,
       status: 'PUBLISHED',
+      publishedAt: { not: null },
     },
     include: {
       ingredients: true,

--- a/backend/src/recipes/recipe.service.ts
+++ b/backend/src/recipes/recipe.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../lib/prisma';
 import { Prisma } from '@prisma/client';
+import { RecipeStatus } from '@prisma/client';
 
 interface RecipeInput {
   title: string;
@@ -100,6 +101,30 @@ export const deleteRecipe = async (recipeId: string, userId: string) => {
 
   await prisma.recipe.delete({
     where: { id: recipeId },
+  });
+};
+
+export const publishRecipe = async (recipeId: string, userId: string) => {
+  await verifyOwnership(recipeId, userId);
+
+  return prisma.recipe.update({
+    where: { id: recipeId },
+    data: {
+      status: RecipeStatus.PUBLISHED,
+      publishedAt: new Date(),
+    },
+  });
+};
+
+export const unpublishRecipe = async (recipeId: string, userId: string) => {
+  await verifyOwnership(recipeId, userId);
+
+  return prisma.recipe.update({
+    where: { id: recipeId },
+    data: {
+      status: RecipeStatus.DRAFT,
+      publishedAt: null,
+    },
   });
 };
 


### PR DESCRIPTION
### What

Implemented draft and publish logic for recipes.

- Added publish and unpublish endpoints
- Enforced ownership validation
- Restricted public APIs to return only published recipes
- Ensured consistent visibility using `RecipeStatus` enum and `publishedAt`

Draft recipes remain private, and only published recipes are accessible publicly.

Resolves #11 